### PR TITLE
fix: disable serial console login to prevent host conflict and deletion of routing policy databse

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Verify on [https://hub.docker.com/](https://hub.docker.com/) that your repositor
 
 ## Steps to Prepare the Host Machine for Running the Edge Gateway Docker Container
 
+### Prerequisites for Host Environment
+
+- Ubuntu 24.04.4 LTS (Noble Numbat)
+
 ### Prerequisite: Install Docker & Docker Compose
 
 ```bash
@@ -112,6 +116,7 @@ EOF
 ```
 
 **Important:** Replace `<USB-ETHERNET-MAC>` and `<ONBOARD-ETHERNET-MAC>` with the actual MAC addresses of your physical interfaces.  
+**Note:** After the OpenWrt container starts on the host, `eth0` will be attached to the LAN bridge and `eth1` will be attached to the WAN bridge.
 
 Find the MAC addresses using:
 
@@ -127,6 +132,20 @@ sudo vi /etc/systemd/network/20-ether-pci.link
 ```
 
 ---
+
+### Preserve host routing policy rules and routes
+
+```bash
+sudo mkdir -p /etc/systemd/networkd.conf.d
+
+sudo tee /etc/systemd/networkd.conf.d/90-openwifi.conf >/dev/null <<'EOF'
+[Network]
+ManageForeignRoutingPolicyRules=no
+ManageForeignRoutes=no
+EOF
+
+sudo systemctl restart systemd-networkd
+```
 
 ###  Create Docker daemon config to avoid iptables conflicts:
 
@@ -150,16 +169,22 @@ sudo reboot
 
 ---
 
-## Steps to Generate Certificates and Replace Default Files
+## Steps to Generate Certificates and Configure Default Files
 
 ### 1. Generate New Certificates
-The process of generating certificates is identical to the method used for the Banana Pi Router.  
+Generate new client and server certificates using the Mango Cloud URL.
+```
+https://github.com/routerarchitects/mango_cloud_cert_generation
+```
 
 ⚠️ **Important:**  
 When creating the certificate, ensure that the **Common Name (CN)** is set to the **MAC address of the `eth0` interface** on the Edge Gateway host machine.
 
 
 ### 2. Replace the Default Certificate and Files
+If you built the image from a branch before `release/4.1.0`, the certificate filenames remain `key.pem`, `cert.pem`, and `cas.pem`.
+
+For `release/4.1.0` and later branches, update `docker-compose/docker-compose.yml`, including the volume mappings, and copy the certificates using the filenames `operational.pem`, `operational.ca`, and `key.pem`.
 
 ```bash
 mkdir -p ~/WORKSPACE && cd ~/WORKSPACE
@@ -179,7 +204,17 @@ Verify `gateway.json` example format:
 ⚠️ **Note:**  
 The configuration must include the **OpenWiFi Controller’s hostname and port number** in order to connect.
 
+### 3. Configure docker-compose.yml
+
 Edit `docker-compose/docker-compose.yml` and update the Docker Hub username inside the docker-compose.yml file:
+
+For branches later than `release/4.0.0`, update the volume mappings as shown below:
+
+```
+      - /home/<username>/WORKSPACE/OPENWIFI-X86/certs/operational.pem:/etc/ucentral/operational.pem:ro
+      - /home/<username>/WORKSPACE/OPENWIFI-X86/certs/key.pem:/etc/ucentral/key.pem:ro
+      - /home/<username>/WORKSPACE/OPENWIFI-X86/certs/operational.ca:/etc/ucentral/operational.ca:ro
+```
 
 ```bash
 vim docker-compose/docker-compose.yml
@@ -212,6 +247,17 @@ sudo cp scripts/openwifi-compose.service /etc/systemd/system/openwifi-compose.se
 sudo vim /etc/systemd/system/openwifi-compose.service
 ```
 
+**Note for Ubuntu Desktop users:**
+Ubuntu Desktop typically uses **NetworkManager** instead of `systemd-networkd` to manage host networking.
+If your host uses NetworkManager, replace the `systemd-networkd` stop/start lines in `openwifi-compose.service` with `NetworkManager.service`.
+
+Example for NetworkManager-based hosts:
+
+```ini
+ExecStartPre=/usr/bin/systemctl stop NetworkManager.service
+ExecStopPost=/usr/bin/systemctl start NetworkManager.service
+```
+
 Update these lines (replace `<your-username>` with your ubuntu's username and `<dockerhub-username>` with your docker-username):
 
 ```
@@ -234,8 +280,17 @@ Reload and enable the service:
 
 ```bash
 sudo systemctl daemon-reload
-sudo systemctl enable openwifi-compose.service #enable for starting at boot
-sudo systemctl start openwifi-compose.service
+sudo systemctl enable openwifi-compose.service # enable for starting at boot
+systemctl start openwifi-compose.service
+
+# Important: For first-time setup, reboot once after enabling the service.
+# This helps ensure host networking and the OpenWrt container initialize cleanly.
+sudo reboot
+```
+
+After the system comes back up:
+
+```bash
 systemctl status openwifi-compose.service
 ```
 

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     network_mode: host                         # same network namespace as host
     privileged: true                           # can manage ip/nftables/routes
     #restart: always
-    tty: true
-    stdin_open: true
+    tty: false
+    stdin_open: false
     volumes:
       - /lib/modules:/lib/modules:ro
       - /home/<username>/WORKSPACE/OPENWIFI-X86/certs/cert.pem:/etc/ucentral/cert.pem:ro
@@ -16,6 +16,7 @@ services:
       - /home/<username>/WORKSPACE/OPENWIFI-X86/certs/cas.pem:/etc/ucentral/cas.pem:ro
       - /home/<username>/WORKSPACE/OPENWIFI-X86/certs/gateway.json:/etc/ucentral/gateway.json:ro
       - /home/<username>/WORKSPACE/OPENWIFI-X86/scripts/openwifi-health.sh:/usr/local/bin/openwifi-health.sh:ro
+      - /home/<username>/WORKSPACE/OPENWIFI-X86/scripts/inittab:/etc/inittab:ro
     dns:
       - 127.0.0.1
     healthcheck:

--- a/scripts/inittab
+++ b/scripts/inittab
@@ -1,0 +1,5 @@
+::sysinit:/etc/init.d/rcS S boot
+::shutdown:/etc/init.d/rcS K shutdown
+#ttyS0::askfirst:/usr/libexec/login.sh
+#hvc0::askfirst:/usr/libexec/login.sh
+#tty1::askfirst:/usr/libexec/login.sh

--- a/scripts/openwifi-compose.service
+++ b/scripts/openwifi-compose.service
@@ -10,8 +10,9 @@ After=network-pre.target
 Type=oneshot
 WorkingDirectory=/home/<your-username>/WORKSPACE/OPENWIFI-X86/docker-compose
 
-ExecStartPre=docker pull <dockerhub-username>/openwifi-x86:latest
-ExecStartPre=systemctl stop systemd-networkd 
+ExecStartPre=/usr/bin/docker pull <dockerhub-username>/openwifi-x86:latest
+ExecStartPre=/usr/bin/systemctl stop systemd-networkd.socket
+ExecStartPre=/usr/bin/systemctl stop systemd-networkd.service
 ExecStartPre=/usr/bin/systemctl stop systemd-resolved
 
 ExecStart=/usr/bin/docker-compose up -d
@@ -21,7 +22,10 @@ ExecStartPost=/usr/bin/bash -lc 'echo "nameserver 127.0.0.1" | tee /etc/resolv.c
 ExecStop=/usr/bin/docker-compose down -v 
 
 ExecStopPost=/usr/bin/bash -lc 'echo "nameserver 127.0.0.53" | tee /etc/resolv.conf >/dev/null'
-ExecStopPost=systemctl start systemd-networkd 
+ExecStopPost=/usr/bin/systemctl start systemd-networkd.socket
+ExecStopPost=/usr/bin/systemctl start systemd-networkd.service
+ExecStopPost=/usr/bin/ip link set lo up
+ExecStopPost=/usr/bin/bash -lc 'ip addr show lo | grep -q "127.0.0.1/8" || ip addr add 127.0.0.1/8 dev lo'
 ExecStopPost=/usr/bin/systemctl start systemd-resolved
 
 RemainAfterExit=yes


### PR DESCRIPTION
 Issue: https://github.com/routerarchitects/ra-openwifi-edge-gateway/issues/5

Fixes: 

 - Commented out ttyS0, hvc0, and tty1 in /etc/inittab
 - Prevents container from hijacking the host's virtual serial port
 - Resolves "Login incorrect" loops on VM consoles when running in privileged mode.
 - Added /etc/systemd/networkd.conf.d/90-openwifi.conf
 - Updated README.md
 - Restore loopback interface after openwifi-container starts